### PR TITLE
[BUG] Cannot read properties of undefined (reading 'includes')

### DIFF
--- a/src/Utils/generics.ts
+++ b/src/Utils/generics.ts
@@ -348,7 +348,7 @@ const UNEXPECTED_SERVER_CODE_TEXT = 'Unexpected server response: '
 
 export const getCodeFromWSError = (error: Error) => {
 	let statusCode = 500
-	if(error.message.includes(UNEXPECTED_SERVER_CODE_TEXT)) {
+	if(error?.message?.includes(UNEXPECTED_SERVER_CODE_TEXT)) {
 		const code = +error.message.slice(UNEXPECTED_SERVER_CODE_TEXT.length)
 		if(!Number.isNaN(code) && code >= 400) {
 			statusCode = code


### PR DESCRIPTION
```
Caught exception: TypeError: Cannot read properties of undefined (reading 'includes')
	at getCodeFromWSError (/home/node/app/node_modules/@adiwajshing/baileys/lib/Utils/generics.js:337:23)
	at WebSocket.<anonymous> (/home/node/app/node_modules/@adiwajshing/baileys/lib/Socket/socket.js:514:116)
	at WebSocket.emit (node:events:525:35)
	at WebSocket.emitClose (/home/node/app/node_modules/ws/lib/websocket.js:258:10)
	at TLSSocket.socketOnClose (/home/node/app/node_modules/ws/lib/websocket.js:1260:15)
	at TLSSocket.emit (node:events:525:35)
	at node:net:298:12
	at TCP.done (node:_tls_wrap:587:7)
```